### PR TITLE
add a CredentialProvider compatible with aws-sdk gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ set in the environment:
 
     $ aws-creds shell <name>
 
+To automatically grab AWS credentials from your keychain when using
+the aws-sdk gem, add the following code:
+
+    AWS.config(:credential_provider => AwsKeychainUtil::CredentialProvider.new('<name>', 'keychain name'))
+
+## Security
+
+Unfortunately, when Keychain whitelists either the `aws-creds` script
+or a ruby application that uses the CredentialProvider for aws-sdk,
+it whitelists `ruby` as a whole. This means *any* ruby script will
+be able to access your AWS credentials. We recommend that you either
+do not whitelist your script at all (don't click "Always Allow"), or
+use a dedicated keychain with an auto-lock interval of less than five
+minutes. Keychains created with `aws-creds` will automatically be
+configured to auto-lock at 5 minutes.
 
 ## Contributing
 

--- a/aws-keychain-util.gemspec
+++ b/aws-keychain-util.gemspec
@@ -1,11 +1,10 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'aws-keychain-util/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "aws-keychain-util"
-  gem.version       = '0.0.3'
+  gem.version       = '0.0.4'
   gem.authors       = ["Zach Wily"]
   gem.email         = ["zach@zwily.com"]
   gem.description   = %q{Helps manage a keychain of AWS credentials on OS X.}

--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -16,14 +16,19 @@ end
 PREFS_FILE = File.expand_path "~/.aws-keychain-util"
 
 def load_keychain
-  unless File.exist? PREFS_FILE
-    puts "You have not set up aws-creds yet. To do so, run:"
-    puts "    #{$0} init"
-    exit 1
+  keychain = if File.exist? PREFS_FILE
+    prefs = JSON.parse(File.read(PREFS_FILE))
+    Keychain.open(prefs['aws_keychain_name'])
+  else
+    Keychain.default
   end
-
-  prefs = JSON.parse(File.read(PREFS_FILE))
-  Keychain.open(prefs['aws_keychain_name'])
+  if keychain.lock_interval > 300
+    $stderr.puts "Your keychain is *not* set to lock automatically in under five minutes. This could be dangerous."
+    if !File.exist? PREFS_FILE
+      $stderr.puts "You should probably run `#{$0} init` to create a new, secure keychain."
+    end
+  end
+  keychain
 end
 
 def get_item(name)

--- a/lib/aws-keychain-util/credential_provider.rb
+++ b/lib/aws-keychain-util/credential_provider.rb
@@ -1,0 +1,20 @@
+require 'keychain'
+
+module AwsKeychainUtil
+  class CredentialProvider
+    include AWS::Core::CredentialProviders::Provider
+
+    def initialize(item = 'AWS', keychain = nil)
+      @item, @keychain = item, keychain
+    end
+
+    def get_credentials
+      keychain = @keychain ? Keychain.open(@keychain) : Keychain.default
+      item = keychain.generic_passwords.where(:label => @item).first
+      {
+        access_key_id: item.attributes[:account],
+        secret_access_key: item.password
+      }
+    end
+  end
+end


### PR DESCRIPTION
so that people can hook directly in, without need to create a
subshell

also allows using the default keychain - some people keep their login
keychain secure enough and may not want to manage multiple keychains
