### PR TITLE
Run one command with AWS env vars set

### DIFF
--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -199,7 +199,7 @@ when 'shell'
 
     exec(aws_env, ENV['SHELL'])
   else
-    system(aws_env, *ARGV)
+    exec(aws_env, *ARGV)
   end
 
 else


### PR DESCRIPTION
If more arguments are passed to aws-creds shell, it'll run the given
command rather than spawning a sub-shell.
