### PR TITLE
improve handling of "default" prefs

### DIFF
--- a/lib/aws-keychain-util.rb
+++ b/lib/aws-keychain-util.rb
@@ -2,16 +2,15 @@ module AwsKeychainUtil
   PREFS_FILE = File.expand_path "~/.aws-keychain-util"
 
   def self.load_keychain
-    keychain = if File.exist? PREFS_FILE
-      prefs = self.prefs
-      Keychain.open(prefs['aws_keychain_name'])
-    else
-      Keychain.default
-    end
-    keychain
+    name = prefs['aws_keychain_name']
+    name ? Keychain.open(name) : Keychain.default
   end
 
   def self.prefs
-    JSON.parse(File.read(PREFS_FILE))
+    if File.exist? PREFS_FILE
+      JSON.parse(File.read(PREFS_FILE))
+    else
+      {}
+    end
   end
 end


### PR DESCRIPTION
so that `shell` command doesn't crash if there isn't one