### PR TITLE
Require aws-sdk-v1 explicitly in CredentialProvider

### DIFF
--- a/lib/aws-keychain-util/credential_provider.rb
+++ b/lib/aws-keychain-util/credential_provider.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'keychain'
 require 'aws-keychain-util'
 


### PR DESCRIPTION
This complements the existing commit bd7274a. Without this, we get a `LoadError`:

```
LoadError: cannot load such file -- aws-sdk
```