### PR TITLE
Set the AWS_SESSION_TOKEN environment variable

### DIFF
--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -151,18 +151,18 @@ when 'mfa'
     sts_item.delete
     sts_token.delete if sts_token
   end
-  
+
   item, token = get_item(item_name)
   sts = AWS::STS.new(:access_key_id => item.attributes[:account], :secret_access_key => item.password)
   begin
     response = sts.new_session(:duration => (60 * 60 * 12), :serial_number => item.attributes[:comment], :token_code => code)
     temp_item = keychain.generic_passwords.create(:label => "#{item_name} mfa",
-                                                  :account => response.credentials[:access_key_id], 
-                                                  :password=> response.credentials[:secret_access_key], 
+                                                  :account => response.credentials[:access_key_id],
+                                                  :password=> response.credentials[:secret_access_key],
                                                   :comment => response.expires_at.to_i.to_s)
     temp_token = keychain.generic_passwords.create(:label => "#{item_name} token",
-                                                  :account => "#{response.credentials[:access_key_id]}_token", 
-                                                  :password=> response.credentials[:session_token], 
+                                                  :account => "#{response.credentials[:access_key_id]}_token",
+                                                  :password=> response.credentials[:session_token],
                                                   :comment => response.expires_at.to_i.to_s)
 
     puts "MultiFactorAuthentication succeeded, expiration is #{response.expires_at}"
@@ -181,6 +181,7 @@ when 'env'
   puts "export AWS_CREDS_NAME=\"#{item.attributes[:label]}\""
   if token
     puts "export AWS_SECURITY_TOKEN=\"#{token.password}\""
+    puts "export AWS_SESSION_TOKEN=\"#{token.password}\""
   end
 
 when 'shell'
@@ -215,4 +216,3 @@ else
   puts "Usage: #{$0} <command> <arguments>"
   puts "  Commands: init, ls, add, cat, env, mfa, rm, shell"
 end
-


### PR DESCRIPTION
It seems `AWS_SESSION_TOKEN` is the new standard for AWS tools and libraries. Probably best to set that alongside `AWS_SECURITY_TOKEN`. Per an [AWS Security Blog post](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs):

> Environment Variables
> 
> All the SDKs except the .NET SDK now can automatically look for credentials in the same environment variables: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. If you're working with temporary security credentials, you can also keep the session token in AWS_SESSION_TOKEN.

Pardon the whitespace changes, that was Atom being opinionated. Let me know if you'd like me to revert those.