### PR TITLE
Update aws-keychain-util.gemspec

### DIFF
--- a/aws-keychain-util.gemspec
+++ b/aws-keychain-util.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('ruby-keychain')
+  gem.add_dependency('ruby-keychain', '~> 0.2.0')
   gem.add_dependency('highline')
   gem.add_dependency('aws-sdk-v1')
 end


### PR DESCRIPTION
getting xplosions on ruby-keychain 0.3.0: https://gist.github.com/landonwilkins/90f3aa033554c508048b