### PR TITLE
Migrate to the AWS-SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ your .bashrc or .zshrc
 To automatically grab AWS credentials from your keychain when using
 the aws-sdk gem, add the following code:
 
-    AWS.config(:credential_provider => AwsKeychainUtil::CredentialProvider.new('<name>', 'keychain name'))
+    require 'aws-keychain-util/credential_provider'
+    Aws.config[:credentials] = AwsKeychainUtil::CredentialProvider.new('<name>', 'keychain name')
 
 To remove an item from your aws keychain:
 

--- a/aws-keychain-util.gemspec
+++ b/aws-keychain-util.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('ruby-keychain', '~> 0.2.0')
   gem.add_dependency('highline')
-  gem.add_dependency('aws-sdk-v1')
+  gem.add_dependency('aws-sdk')
 end

--- a/aws-keychain-util.gemspec
+++ b/aws-keychain-util.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('ruby-keychain', '~> 0.2.0')
   gem.add_dependency('highline')
-  gem.add_dependency('aws-sdk')
+  gem.add_dependency('aws-sdk', '> 2.0')
 end

--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -9,7 +9,7 @@ require 'highline'
 require 'keychain'
 require 'json'
 require 'aws-keychain-util'
-require 'aws-sdk-v1'
+require 'aws-sdk'
 
 def ask(question)
   HighLine.new.ask(question)
@@ -153,20 +153,20 @@ when 'mfa'
   end
 
   item, token = get_item(item_name)
-  sts = AWS::STS.new(:access_key_id => item.attributes[:account], :secret_access_key => item.password)
+  sts = Aws::STS::Client.new(:access_key_id => item.attributes[:account], :secret_access_key => item.password)
   begin
-    response = sts.new_session(:duration => (60 * 60 * 12), :serial_number => item.attributes[:comment], :token_code => code)
+    response = sts.get_session_token(:duration_seconds => (60 * 60 * 12), :serial_number => item.attributes[:comment], :token_code => code)
     temp_item = keychain.generic_passwords.create(:label => "#{item_name} mfa",
                                                   :account => response.credentials[:access_key_id],
                                                   :password=> response.credentials[:secret_access_key],
-                                                  :comment => response.expires_at.to_i.to_s)
+                                                  :comment => response.credentials[:expiration].to_i.to_s)
     temp_token = keychain.generic_passwords.create(:label => "#{item_name} token",
                                                   :account => "#{response.credentials[:access_key_id]}_token",
                                                   :password=> response.credentials[:session_token],
-                                                  :comment => response.expires_at.to_i.to_s)
+                                                  :comment => response.credentials[:expiration].to_i.to_s)
 
-    puts "MultiFactorAuthentication succeeded, expiration is #{response.expires_at}"
-  rescue AWS::STS::Errors::AccessDenied => e
+    puts "MultiFactorAuthentication succeeded, expiration is #{response.credentials[:expiration]}"
+  rescue Aws::STS::Errors::AccessDenied => e
     puts e.to_s
   end
 

--- a/lib/aws-keychain-util/credential_provider.rb
+++ b/lib/aws-keychain-util/credential_provider.rb
@@ -4,7 +4,7 @@ require 'aws-keychain-util'
 
 module AwsKeychainUtil
   class CredentialProvider
-    include AWS::Core::CredentialProviders::Provider
+    include Aws::CredentialProvider
 
     attr_reader :item, :keychain
 
@@ -12,14 +12,10 @@ module AwsKeychainUtil
       @item, @keychain = item, keychain
     end
 
-    def get_credentials
+    def credentials
       keychain = @keychain ? Keychain.open(@keychain) : AwsKeychainUtil.load_keychain
-      item = keychain.generic_passwords.where(:label => @item).first
-      return {} unless item
-      {
-        access_key_id: item.attributes[:account],
-        secret_access_key: item.password
-      }
+      item = keychain.generic_passwords.where(label: @item).first
+      Aws::Credentials.new(item.attributes[:account], item.password)
     end
   end
 end


### PR DESCRIPTION
Hi @zwily This pull request updated the gem to use the AWS-SDK v2 gem and a second commit that is just style changes made by Rubocop. I can drop the second one if you would rather just the functional change.