### PR TITLE
fix cross account assume role.

### DIFF
--- a/bin/aws-creds
+++ b/bin/aws-creds
@@ -119,8 +119,8 @@ when 'init'
   keychain.lock_interval = 300
   keychain.lock_on_sleep = true
 
-  $prefs = { 'aws_keychain_name' => name, 'shell_arguments' => shell_arguments }
-  File.new(AwsKeychainUtil::PREFS_FILE, 'w').write JSON.dump($prefs)
+  prefs = { 'aws_keychain_name' => name, 'shell_arguments' => shell_arguments }
+  File.new(AwsKeychainUtil::PREFS_FILE, 'w').write JSON.dump(prefs)
 
   puts 'Your AWS keychain has been created and configured to auto-lock after'
   puts '5 minutes, and when sleeping. You can change those options in'
@@ -143,7 +143,7 @@ when 'add'
   name     =        ask('      account name: ')
   account  =        ask('     access key id: ')
   password = ask_secure(' secret_access_key: ')
-  arn      =        ask('           mfa arn: ')
+  arn      =        ask('(optional) mfa arn: ')
 
   item = keychain.generic_passwords.create(
     label: name,
@@ -164,15 +164,12 @@ when 'rm'
 
 when 'add-role'
   keychain = load_keychain
-  name = get_name_from_args_for_command('add-role')
-  item = get_valid_item(name)
-
-  role     = ask('         role name: ')
-  arn      = ask('          role arn: ')
+  role_name = ask('         role name: ')
+  arn       = ask('          role arn: ')
 
   keychain.generic_passwords.create(
-    label: "#{name} role #{role}",
-    account: role,
+    label: "role #{role_name}",
+    account: role_name,
     password: '',
     comment: arn
   )
@@ -184,7 +181,7 @@ when 'assume-role'
   code = ARGV.shift
 
   unless name
-    puts "Usage: #{$PROGRAM_NAME} assume-role <name> <role-name> [<mfa>]"
+    puts "Usage: #{$PROGRAM_NAME} assume-role <name> <role-name> [<mfa-code>]"
     exit 1
   end
 
@@ -200,7 +197,7 @@ when 'assume-role'
 
   exit 0 if 'none' == role_name || role_name.nil?
 
-  item_role = get_valid_item("#{name} role #{role_name}")
+  item_role = get_valid_item("role #{role_name}")
 
   sts = Aws::STS::Client.new(access_key_id: item.attributes[:account], secret_access_key: item.password)
 
@@ -223,7 +220,7 @@ when 'assume-role'
       keychain.generic_passwords.create(label: "#{name} role-token",
                                         account: "#{response.credentials[:access_key_id]}_token",
                                         password: response.credentials[:session_token],
-                                        comment: "#{name} role #{role_name}")
+                                        comment: "role #{role_name}")
 
       puts "AssumeRoleAuthentication succeeded, expiration is #{response.credentials[:expiration]}"
     rescue Aws::STS::Errors::AccessDenied => e


### PR DESCRIPTION
This PR fixes assuming a role across-account by removing the account restriction on the roles. @simonista 
BREAKING CHANGE: If you have roles already you would need to remove the account prefix via the Keychain Util.